### PR TITLE
Stop Dependabot bumping fhir.core.version independently

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: "/fhir-mapbuilder-validation"
     schedule:
       interval: "weekly"
+    ignore:
+      # fhir.core.version must stay whatever version health.matchbox:matchbox-engine
+      # itself requires — never bumped independently, or the two can drift out of
+      # compatibility. Bump it by hand alongside a matchbox-engine version bump instead.
+      - dependency-name: "ca.uhn.hapi.fhir:org.hl7.fhir.r4"
+      - dependency-name: "ca.uhn.hapi.fhir:org.hl7.fhir.r5"
 
   - package-ecosystem: "npm"
     directory: "/vscode-extension"


### PR DESCRIPTION
## Summary

- `fhir.core.version` must stay whatever `health.matchbox:matchbox-engine` itself requires (hard constraint from wayfinder map #28) — never bumped independently of Matchbox, or the two can drift out of compatibility.
- PR #34 (Dependabot: `fhir.core.version` 6.10.0 → 6.10.2) does exactly that — closing it, not merging.
- Adds an `ignore` rule for `ca.uhn.hapi.fhir:org.hl7.fhir.r4`/`org.hl7.fhir.r5` on the `maven` ecosystem so Dependabot stops proposing this on its own. Future bumps happen by hand alongside a Matchbox version bump (as done in #32/#29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTMFKNR9hG98M6mF6cyRWk