### PR TITLE
Defer Spring Boot 4 migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       # compatibility. Bump it by hand alongside a matchbox-engine version bump instead.
       - dependency-name: "ca.uhn.hapi.fhir:org.hl7.fhir.r4"
       - dependency-name: "ca.uhn.hapi.fhir:org.hl7.fhir.r5"
+      # Spring Boot 4 migration deferred (wayfinder map #48, decision ticket #50):
+      # small effort, no blocker found, just not scheduled yet. Still take
+      # minor/patch updates within the 3.x line automatically.
+      - dependency-name: "org.springframework.boot:spring-boot-starter-parent"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/vscode-extension"


### PR DESCRIPTION
## Summary

Resolves wayfinder map #48. Decision: migrate to Spring Boot 4 later, not now — research (#49) found it's a small effort (one import relocation, no other breaking changes on this module's actual API surface) with no real blocker, but it's not scheduled work.

- Ignores major-version bumps for `spring-boot-starter-parent` in `.github/dependabot.yml` — still takes 3.x minor/patch updates automatically, mirroring the `fhir.core.version` ignore rule from #42.
- PR #35 (the Dependabot proposal that triggered this) is being closed separately with a pointer back here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTMFKNR9hG98M6mF6cyRWk