### PR TITLE
Add configurable JVM args for the matchbox java process

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -79,6 +79,11 @@ The current \output\package.tgz file (assuming that the user is working on a FHI
 
 * Building the IG is also detected (output/qa.json creation specifically) and lead to the loading of 'output/package.tgz'.
 
+#### Configuration
+The `FhirMapBuilder.javaVmArgs` setting lets you pass extra JVM arguments to the matchbox java process (inserted
+before `-jar`), notably memory settings such as `-Xmx4g -Xms512m` if the engine runs out of heap on large packages.
+Leave it empty to use the JVM defaults.
+
 #### Troubleshooting
 The FHIR MapBuilder use the output/package.tgz file to configure the matchbox-engine, which is the standardized place to
 store the package in a FIG building process. However, depending on your use case, you may not need such package.
@@ -86,6 +91,16 @@ There is no control for the `Validate StructureMap (Current input)` feature to m
 package while it should, the validation won't success (of course). In such scenario, you'll find a message in the error
 output file with the `"messageId": "TYPE_SPECIFIC_CHECKS_DT_CANONICAL_RESOLVE"`. This error also happen if the wrong
 package is loaded.
+
+**Out of memory / heap errors**: prefer setting `FhirMapBuilder.javaVmArgs` (e.g. `-Xmx4g`) as described above. Until
+that setting is available (older extension versions), a workaround is to set a persistent `JAVA_TOOL_OPTIONS`
+environment variable for your Windows user account, which every JVM picks up automatically:
+```powershell
+[System.Environment]::SetEnvironmentVariable("JAVA_TOOL_OPTIONS", "-Xmx4g", "User")
+```
+This applies to all Java processes run by your user account (not just this extension) and requires a restart of
+VS Code (or a re-login) to take effect. Remove it with the same command using an empty string once
+`FhirMapBuilder.javaVmArgs` covers your needs.
 
 ## Templates
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -62,6 +62,11 @@
           "type": "string",
           "default": "",
           "description": "Optional path to a specific Java executable. Leave empty to use the system default."
+        },
+        "FhirMapBuilder.javaVmArgs": {
+          "type": "string",
+          "default": "",
+          "description": "Additional JVM arguments passed to the matchbox java process before -jar, e.g. \"-Xmx4g -Xms512m\" to configure heap memory. Leave empty to use the JVM defaults."
         }
       }
     },

--- a/vscode-extension/src/MapBuilderJavaProcess.ts
+++ b/vscode-extension/src/MapBuilderJavaProcess.ts
@@ -60,6 +60,7 @@ export class MapBuilderJavaProcess {
         const args = [
             `-Dserver.port=${ApiConstants.apiServerPort}`,
             `-Dfile.encoding=UTF-8`,
+            ...this.getJavaVmArgs(),
             "-jar",
             jarPath
         ];
@@ -74,6 +75,11 @@ export class MapBuilderJavaProcess {
 
         const command = this.validateJavaPath(this.config.get<string>("javaExecutablePath"));
         return {command, args};
+    }
+
+    private getJavaVmArgs(): string[] {
+        const javaVmArgs = this.config.get<string>("javaVmArgs") ?? "";
+        return javaVmArgs.split(/\s+/).filter((arg) => arg.length > 0);
     }
 
     private isFileExists(path: string): boolean {


### PR DESCRIPTION
## Summary
- Adds a `FhirMapBuilder.javaVmArgs` VS Code setting so users can pass extra JVM options (e.g. `-Xmx4g -Xms512m`) to the matchbox java process, inserted before `-jar`.
- Documents the setting in the README, along with a `JAVA_TOOL_OPTIONS` workaround for older extension versions.

## Test plan
- [x] `npm run check-types` passes
- [x] `npm run lint` shows no new warnings/errors
- [x] Manually verify in VS Code that setting `FhirMapBuilder.javaVmArgs` to `-Xmx4g` is reflected in the spawned java command line (extension output channel logs the full command)

https://claude.ai/code/session_012qiipHKxaGCLy8n2vTWy6z