### PR TITLE
Pin @types/vscode to engines.vscode's minimum

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,9 @@ updates:
     directory: "/vscode-extension"
     schedule:
       interval: "weekly"
+    ignore:
+      # @types/vscode's minor version tracks the VS Code release it targets, so
+      # bumping it ahead of engines.vscode makes `vsce package` fail with
+      # "@types/vscode greater than engines.vscode". Bump it by hand alongside
+      # an engines.vscode bump instead.
+      - dependency-name: "@types/vscode"

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -19,7 +19,7 @@
         "@types/node": "^26.2.0",
         "@types/semver": "^7.8.0",
         "@types/sinon": "^22.0.0",
-        "@types/vscode": "^1.125.0",
+        "@types/vscode": "1.91.0",
         "@types/yaml": "^1.9.7",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
@@ -1499,9 +1499,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
-      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "version": "1.91.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.91.0.tgz",
+      "integrity": "sha512-PgPr+bUODjG3y+ozWUCyzttqR9EHny9sPAfJagddQjDwdtf66y2sDKJMnFZRuzBA2YtBGASqJGPil8VDUPvO6A==",
       "dev": true,
       "license": "MIT"
     },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -165,7 +165,7 @@
     "@types/node": "^26.2.0",
     "@types/semver": "^7.8.0",
     "@types/sinon": "^22.0.0",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "1.91.0",
     "@types/yaml": "^1.9.7",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",


### PR DESCRIPTION
## Summary
- Dependabot PR #53 bumped `@types/vscode` from `1.103.0` to `1.125.0` without touching `engines.vscode` (`^1.91.0`). CI (check-types/lint/test) didn't catch it because it never runs `vsce package`, but the packaging step from the install procedure fails with:
  ```
  ERROR  @types/vscode ^1.125.0 greater than engines.vscode ^1.91.0. Either upgrade engines.vscode or use an older @types/vscode version
  ```
- Pins `@types/vscode` back to `1.91.0` (matching `engines.vscode`'s declared minimum) and adds a Dependabot `ignore` rule for it, following the same pattern already used for `fhir.core.version` and `spring-boot-starter-parent`.

## Test plan
- [x] `npm run check-types` passes
- [x] `npm run lint` — no new warnings
- [x] `npm run package` succeeds
- [x] `npx vsce package --baseImagesUrl=...` succeeds (previously failed with the engines/types error)

https://claude.ai/code/session_012qiipHKxaGCLy8n2vTWy6z