### PR TITLE
CI: run vsce package in the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,9 @@ jobs:
       - name: Run tests (with xvfb)
         run: xvfb-run -a npm test
         working-directory: vscode-extension
+
+      - name: Package extension
+        # Catches issues npm run compile misses, e.g. @types/vscode ahead of engines.vscode.
+        # The fhir-mapbuilder-validation jar isn't built here; vsce packages without it.
+        run: npx vsce package --baseImagesUrl=https://raw.githubusercontent.com/aphp/fhir-mapbuilder/refs/heads/main/vscode-extension
+        working-directory: vscode-extension


### PR DESCRIPTION
## Summary
- The test workflow (`test.yml`, runs on every push/PR to `main`) never ran `vsce package`, only `check-types`/`lint`/`test`. That's how the `@types/vscode` 1.125.0 vs `engines.vscode` ^1.91.0 mismatch (fixed in #59) slipped through CI and only surfaced when packaging locally.
- Adds a `vsce package --baseImagesUrl=...` step after the test step, so this class of error is caught on every PR going forward.
- No Maven/Java setup added: the `fhir-mapbuilder-validation` jar isn't built in this workflow, and `vsce package` succeeds fine without `target/*.jar` present (verified locally) — it just omits that file from the vsix.

## Test plan
- [x] Verified locally that `npx vsce package --baseImagesUrl=...` succeeds both with and without `vscode-extension/target/fhir-mapbuilder-validation.jar` present
- [x] CI run on this PR exercises the new step

https://claude.ai/code/session_012qiipHKxaGCLy8n2vTWy6z