### PR TITLE
Release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 1.6.0 (2026-08-24)
+
+Added
+
+* `FhirMapBuilder.javaVmArgs` setting to pass extra JVM arguments (e.g. `-Xmx4g`) to the matchbox java process, to configure heap memory without patching the extension
+* `vsce package` step in the test workflow, catching packaging issues (e.g. `@types/vscode`/`engines.vscode` mismatches) on every PR
+
+Fixed
+
+* Pinned `@types/vscode` back to `engines.vscode`'s minimum (1.91.0), fixing a `vsce package` failure introduced by an automated dependency bump
+
 ## 1.5.0 (2026-08-21)
 
 Changed

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "FHIR MapBuilder",
   "description": "FHIR Mapping Language (FML) support and FHIR StructureMap resources validation.",
   "icon": "ext-images/icon.ico",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "publisher": "aphp",
   "readme": "README.md",
   "author": {


### PR DESCRIPTION
## Summary
- Bump `vscode-extension/package.json` version to 1.6.0
- Add CHANGELOG entry for 1.6.0: `FhirMapBuilder.javaVmArgs` setting, `vsce package` CI check, and the `@types/vscode`/`engines.vscode` fix

## Test plan
- [x] `npm run check-types` passes
- [ ] Once merged, tag `v1.6.0` on main to trigger `release.yml` (builds the jar, `vsce package`, publishes a GitHub Release)

https://claude.ai/code/session_012qiipHKxaGCLy8n2vTWy6z